### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -8,7 +8,7 @@ on:
       - reopened
   push:
     branches:
-      - master
+      - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
@@ -103,6 +103,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          body: ${{ steps.changelog_reader.outputs.log_entry }}
-          files: |
-            dist/*
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          files: target/release/retrieve


### PR DESCRIPTION
Fixes the CI workflow. The workflow was not running on the `main` branch
as it was still using `master` and the release action was incorrectly
configured.
