### PR TITLE
Ensure destination folder exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bug preventing the downloads to start if the destination folder did not
+  exist. [#9]
+
 ## [0.1.1] - 2022-01-16
 
 ### Added
@@ -23,3 +28,4 @@ Initial version.
 
 [#3]: https://github.com/PeopleForBikes/retrieve/pull/3
 [#4]: https://github.com/PeopleForBikes/retrieve/pull/4
+[#9]: https://github.com/PeopleForBikes/retrieve/pull/9

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use color_eyre::{eyre::Report, Result};
 use downloader::{Download, Downloader};
 use retrieve::cli::Args;
 use retrieve::{setup, City};
+use std::fs;
 
 fn main() -> Result<(), Report> {
     // Setup the application.
@@ -10,7 +11,6 @@ fn main() -> Result<(), Report> {
 
     // Read the CLI arguments.
     let args = Args::parse();
-    // dbg!(&args);
 
     // Prepare the variable holding the list of cities to process.
     let mut cities: Vec<City> = Vec::new();
@@ -18,12 +18,16 @@ fn main() -> Result<(), Report> {
     // Prepare the list of items to retrieve from a CSV file.
     if let Some(csv) = args.from_csv {
         cities = City::from_csv(csv)?;
-        // dbg!(&cities);
+    }
+
+    // Ensure the output folder exists.
+    if !args.destination_folder.exists() {
+        fs::create_dir_all(&args.destination_folder)?;
     }
 
     // Prepare the downloader.
     let mut downloader = Downloader::builder()
-        .download_folder(std::path::Path::new(&args.destination_folder))
+        .download_folder(&args.destination_folder)
         .parallel_requests(args.parallel_requests)
         .retries(args.retries)
         .build()
@@ -33,13 +37,11 @@ fn main() -> Result<(), Report> {
     let downloads = cities
         .iter()
         .filter(|c| !c.uuid.is_empty())
-        // .take(5)
         .map(|c| {
             downloader::Download::new(c.url(args.dataset).unwrap().as_str())
                 .file_name(std::path::Path::new(&c.zip_name()))
         })
         .collect::<Vec<Download>>();
-    // dbg!(&downloads.len());
 
     // Start the download operations.
     let _dl_result = downloader.download(&downloads);


### PR DESCRIPTION
Ensures the destination folder exists before initiating the downloads.
If the folder, or any of its parent does not exists, it will be created.

Fixes PeopleForBikes/retrieve#7
