### PR TITLE
Add feature to retrieve  'Overall Scores'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ const PFB_S3_STORAGE_BASE_URL: &str =
 
 /// Represent the name of the "neighborhood ways" dataset.
 const DS_NEIGHBORHOOD_WAYS: &str = "neighborhood_ways";
+const DS_NEIGHBORHOOD_OVERALL_SCORES: &str = "neighborhood_overall_scores";
 
 /// Setup the application.
 ///
@@ -28,12 +29,14 @@ pub fn setup() -> Result<(), Report> {
 #[derive(Debug, PartialEq, PartialOrd, ArgEnum, Clone, Copy)]
 pub enum Dataset {
     NeighborhoodWays,
+    NeighborhoodOverallScores,
 }
 
 impl From<&str> for Dataset {
     fn from(item: &str) -> Self {
         match item {
             DS_NEIGHBORHOOD_WAYS => Dataset::NeighborhoodWays,
+            DS_NEIGHBORHOOD_OVERALL_SCORES => Dataset::NeighborhoodOverallScores,
             _ => panic!("Cannot parse dataset name {}", item),
         }
     }
@@ -43,6 +46,7 @@ impl fmt::Display for Dataset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Dataset::NeighborhoodWays => write!(f, "{}", DS_NEIGHBORHOOD_WAYS),
+            Dataset::NeighborhoodOverallScores => write!(f, "{}", DS_NEIGHBORHOOD_OVERALL_SCORES),
         }
     }
 }
@@ -96,6 +100,11 @@ impl City {
         format!("{}.zip", self.full_name())
     }
 
+    /// Return the full name of the city with the `.csv` extension.
+    pub fn csv_name(&self) -> String {
+        format!("{}.csv", self.full_name())
+    }
+
     /// Return the URL of the neighborhood_ways data set.
     pub fn neighborhood_ways_url(&self) -> Result<Url, Report> {
         let dataset_url = format!(
@@ -108,10 +117,23 @@ impl City {
         Ok(url)
     }
 
+    /// Return the URL of the neighborhood_overall_scores data set.
+    pub fn neighborhood_overall_scores_url(&self) -> Result<Url, Report> {
+        let dataset_url = format!(
+            "{}/{}/{}.csv",
+            PFB_S3_STORAGE_BASE_URL,
+            self.uuid,
+            Dataset::NeighborhoodOverallScores
+        );
+        let url = Url::parse(&dataset_url)?;
+        Ok(url)
+    }
+
     /// Return the URL of the specified `dataset`.
     pub fn url(&self, dataset: Dataset) -> Result<Url, Report> {
         match dataset {
             Dataset::NeighborhoodWays => self.neighborhood_ways_url(),
+            Dataset::NeighborhoodOverallScores => self.neighborhood_overall_scores_url(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use color_eyre::{eyre::Report, Result};
 use downloader::{Download, Downloader};
 use retrieve::cli::Args;
-use retrieve::{setup, City};
+use retrieve::{setup, City, Dataset};
 use std::fs;
 
 fn main() -> Result<(), Report> {
@@ -34,14 +34,24 @@ fn main() -> Result<(), Report> {
         .unwrap();
 
     // Prepare the downloads.
-    let downloads = cities
-        .iter()
-        .filter(|c| !c.uuid.is_empty())
-        .map(|c| {
-            downloader::Download::new(c.url(args.dataset).unwrap().as_str())
-                .file_name(std::path::Path::new(&c.zip_name()))
-        })
-        .collect::<Vec<Download>>();
+    let downloads = match args.dataset {
+        Dataset::NeighborhoodWays => cities
+            .iter()
+            .filter(|c| !c.uuid.is_empty())
+            .map(|c| {
+                downloader::Download::new(c.url(args.dataset).unwrap().as_str())
+                    .file_name(std::path::Path::new(&c.zip_name()))
+            })
+            .collect::<Vec<Download>>(),
+        Dataset::NeighborhoodOverallScores => cities
+            .iter()
+            .filter(|c| !c.uuid.is_empty())
+            .map(|c| {
+                downloader::Download::new(c.url(args.dataset).unwrap().as_str())
+                    .file_name(std::path::Path::new(&c.csv_name()))
+            })
+            .collect::<Vec<Download>>(),
+    };
 
     // Start the download operations.
     let _dl_result = downloader.download(&downloads);


### PR DESCRIPTION
Add 'Overall Scores' to 'city datasets' enum and
associated functions so that the cli can be used to download the
Overall Scores csvs from the BNA.

Fixes #14

Types of changes
----------------
- New feature (non-breaking change which adds functionality)

Description
-----------
Added `NeighborhoodOverallScores` to `enum Dataset` and a few more lines of code to enable the cli to download 'Overall Scores' from the BNA tool. This allows users to use retrieve to also download 'Overall Scores' csv files.

Checklist:
----------
- [] I have updated the documentation accordingly
- [] I have updated the Changelog (if applicable)

Fixes PeopleForBikes/retrieve#14

